### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/public/js/bootstrap.js
+++ b/public/js/bootstrap.js
@@ -1075,7 +1075,7 @@
           return;
         }
 
-        var target = $(selector)[0];
+        var target = $.find(selector)[0];
 
         if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
           return;


### PR DESCRIPTION
Fixes [https://github.com/121yaseen/pistah/security/code-scanning/1](https://github.com/121yaseen/pistah/security/code-scanning/1)

To fix the problem, we need to ensure that the `selector` value is properly sanitized before it is used in the jQuery `$` function. One way to achieve this is to use the `$.find` function instead of `$`, as `$.find` will only interpret the `selector` as a CSS selector and never as HTML. This change will prevent any potential XSS attacks by ensuring that the `selector` is treated as a safe CSS selector.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
